### PR TITLE
Pin postgres major version in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,12 @@
     {
       "matchDepNames": ["scala"],
       "allowedVersions": "<3.0.0"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["postgres"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Postgres major upgrades require a data migration (`pg_dump`/`pg_upgrade`); a silent Renovate bump from N to N+1 produces a CrashLoopBackOff on existing PVCs — as just happened here with 16→18. This rule prevents Renovate from opening a major-bump PR for the postgres image, while still allowing minor/patch/digest updates.

Mirrored to `foodie` and `pubquiz-server`.